### PR TITLE
Treat closing dialog (e.g. by pressing ESC) as cancel.

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -3329,6 +3329,7 @@
     (condp = result
       JOptionPane/NO_OPTION false
       JOptionPane/CANCEL_OPTION nil
+      JOptionPane/CLOSED_OPTION nil
       true)))
 
 (defn confirm


### PR DESCRIPTION
I discovered that in my project that makes heavy use of seesaw, when people hit the ESC key thinking that they will cancel the dangerous operation they changed their mind about, instead the operation is completed. This change should fix the problem within seesaw, treating the ESC key the same as pressing the Cancel button in  a `seesaw/confirm` dialog, rather than (as it does today) pressing the OK button. (See https://docs.oracle.com/javase/7/docs/api/javax/swing/JOptionPane.html for details.)

In the mean time, I’m going to have to replace all my uses of `seesaw/confirm` with something safer.